### PR TITLE
HTTP/2: removed ngx_debug_point() call.

### DIFF
--- a/src/http/v2/ngx_http_v2.c
+++ b/src/http/v2/ngx_http_v2.c
@@ -2466,10 +2466,6 @@ ngx_http_v2_connection_error(ngx_http_v2_connection_t *h2c,
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, h2c->connection->log, 0,
                    "http2 state connection error");
 
-    if (err == NGX_HTTP_V2_INTERNAL_ERROR) {
-        ngx_debug_point();
-    }
-
     ngx_http_v2_finalize_connection(h2c, err);
 
     return NULL;


### PR DESCRIPTION
    
With the recent change to prevent frames flood in d4448892a294,
nginx will finalize the connection with NGX_HTTP_V2_INTERNAL_ERROR
whenever flood is detected, causing nginx aborting or stopping if
the debug_points directive is used in nginx config.